### PR TITLE
Enables Travis Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.0.0
   - rbx


### PR DESCRIPTION
Enabling Travis cache should make builds faster (if there's no changes in gems versions).

Tell me if there's something more to do! :smile: 